### PR TITLE
Track deleted objects

### DIFF
--- a/certora_sui_summaries/sources/sui_object_summaries.move
+++ b/certora_sui_summaries/sources/sui_object_summaries.move
@@ -3,7 +3,6 @@ module certora::sui_object_summaries;
 
 use cvlm::asserts::cvlm_assume_msg;
 use cvlm::manifest::{ summary, ghost, field_access };
-use cvlm::asserts::cvlm_assert_msg;
 
 fun cvlm_manifest() {
     ghost(b"is_id");
@@ -16,7 +15,7 @@ fun cvlm_manifest() {
 }
 
 
-public native fun deleted(): &mut vector<address>;
+public native fun deleted(id: address): &mut bool;
 
 // #[field_access(id), summary(sui::object::borrow_uid)]
 native fun borrow_uid<T: key>(obj: &T): &UID;
@@ -33,9 +32,7 @@ public fun record_new_uid(id: address) {
 
 // #[summary(sui::object::delete_impl)]
 fun delete_impl(id: address) {
-    // The Sui implementation does some bookkeeping that isn't visible to user code
-    let old_len = deleted().length();
-    deleted().push_back(id);
-    cvlm_assert_msg(deleted().length() == old_len+1, b"Length mismatch")
+    cvlm_assume_msg(!*deleted(id), b"Deleted existing object");
+    *deleted(id) = true;
 }
 


### PR DESCRIPTION
Uses summary to tracks deleted objects in the ghost function 

```move 
public native fun deleted(id: address): &mut bool;
```

A summary for `delete_impl` sets `deleted(id)` to true whenever the (object with address) `id` is deleted.