### PR TITLE
`sui::object::borrow_uid` support for nondet types

### DIFF
--- a/certora_sui_summaries/sources/sui_object_summaries.move
+++ b/certora_sui_summaries/sources/sui_object_summaries.move
@@ -3,11 +3,13 @@ module certora::sui_object_summaries;
 
 use cvlm::asserts::cvlm_assume_msg;
 use cvlm::manifest::{ summary, ghost, field_access };
+use cvlm::nondet::is_nondet_type;
 
 fun cvlm_manifest() {
     ghost(b"is_id");
     ghost(b"deleted");
-    field_access(b"borrow_uid", b"id");
+    field_access(b"borrow_uid_field", b"id");
+    ghost(b"borrow_nondet_type_uid");
     summary(b"record_new_uid", @sui, b"object", b"record_new_uid");
     summary(b"delete_impl", @sui, b"object", b"delete_impl");
     summary(b"borrow_uid", @sui, b"object", b"borrow_uid");
@@ -15,10 +17,23 @@ fun cvlm_manifest() {
 }
 
 
+// #[ghost]
 public native fun deleted(id: address): &mut bool;
 
+// #[field_access(id)]
+native fun borrow_uid_field<T: key>(obj: &T): &UID;
+
+// #[ghost]
+native fun borrow_nondet_type_uid<T>(): &UID;
+
 // #[field_access(id), summary(sui::object::borrow_uid)]
-native fun borrow_uid<T: key>(obj: &T): &UID;
+fun borrow_uid<T: key>(obj: &T): &UID {
+    if (is_nondet_type<T>()) {
+        borrow_nondet_type_uid<T>()
+    } else {
+        borrow_uid_field(obj)
+    }
+}
 
 // #[ghost]
 native fun is_id(id: address): &mut bool;

--- a/certora_sui_summaries/sources/sui_object_summaries.move
+++ b/certora_sui_summaries/sources/sui_object_summaries.move
@@ -24,12 +24,12 @@ public native fun deleted(id: address): &mut bool;
 native fun borrow_uid_field<T: key>(obj: &T): &UID;
 
 // #[ghost]
-native fun borrow_nondet_type_uid<T>(): &UID;
+native fun borrow_nondet_type_uid<T>(obj: &T): &UID;
 
 // #[field_access(id), summary(sui::object::borrow_uid)]
 fun borrow_uid<T: key>(obj: &T): &UID {
     if (is_nondet_type<T>()) {
-        borrow_nondet_type_uid<T>()
+        borrow_nondet_type_uid(obj)
     } else {
         borrow_uid_field(obj)
     }

--- a/certora_sui_summaries/sources/sui_object_summaries.move
+++ b/certora_sui_summaries/sources/sui_object_summaries.move
@@ -26,7 +26,7 @@ native fun borrow_uid_field<T: key>(obj: &T): &UID;
 // #[ghost]
 native fun borrow_nondet_type_uid<T>(obj: &T): &UID;
 
-// #[field_access(id), summary(sui::object::borrow_uid)]
+// #[summary(sui::object::borrow_uid)]
 fun borrow_uid<T: key>(obj: &T): &UID {
     if (is_nondet_type<T>()) {
         borrow_nondet_type_uid(obj)

--- a/cvlm/sources/manifest.move
+++ b/cvlm/sources/manifest.move
@@ -143,6 +143,11 @@ public native fun shadow(function_name: vector<u8>);
 /// 
 /// If a type is passed to the accessor function that is not a struct, or does not have a field with the given name,
 /// or if the field is the wrong type, the Prover will raise an error.
+///
+/// Note that "nondeterministic types" are not supported as type parameters to field accessors, since the Prover does
+/// not have a way to determine what fields such types have.  Summaries can work around this by using 
+/// `cvlm::nondet::is_nondet_type` to check for nondeterministic types, and take appropriate alternate actions in that 
+/// case.
 /// 
 /// (This function is provided to support summarization of platform functions; for normal functions, prefer to use an 
 /// ordinary (test-only) accessor function to access fields from rules or summaries.)

--- a/cvlm/sources/nondet.move
+++ b/cvlm/sources/nondet.move
@@ -9,3 +9,7 @@ public macro fun nondet_with<$T>($msg: vector<u8>, $f: |$T| -> bool): $T {
     cvlm_assume_msg($f(value), $msg);
     value
 }
+
+/// Returns true if the type of T is not statically known to the Prover.  For example, a generic rule's type arguments
+/// are nondeterministic; `is_nondet_type<T>()` will return true for such type arguments.
+public native fun is_nondet_type<T>(): bool;


### PR DESCRIPTION
If the type `T` in a call to `borrow_uid<T>` is nondet, use a ghost mapping instead of the field accessor.